### PR TITLE
Removed manual click handling

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 
 group = "in.porter.douglasjunior"
-version = "0.2.3.2"
+version = "0.2.3.3"
 
 android {
     compileSdkVersion 28

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -386,11 +386,10 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         mAnchorView.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
-                if(event.getAction() == MotionEvent.ACTION_UP) {
-                    mAnchorView.performClick();
-                    if (popUpActionListener != null) popUpActionListener.onPopUpClicked();
+                if (event.getAction() == MotionEvent.ACTION_UP && popUpActionListener != null){
+                    popUpActionListener.onPopUpClicked();
                 }
-                return true;
+                return false;
             }
         });
     }


### PR DESCRIPTION
With this, we're getting rid of the manual click handling of the anchorView and passing the touch events down the view hierarchy by returning false in the `onTouch` event.