### PR TITLE
Crash due to delay in SimpleTooltip fixed

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 
 group = "in.porter.douglasjunior"
-version = "0.2.3.3"
+version = "0.2.3.4"
 
 android {
     compileSdkVersion 28

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -487,6 +487,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     };
 
     private void updatePopUpLocation() {
+        if(mPopupWindow == null) return;
         PointF location = calculePopupLocation();
         mPopupWindow.setClippingEnabled(true);
         mPopupWindow.update((int) location.x + xOffSetPopUp, (int) location.y + yOffSetPopUp, mPopupWindow.getWidth(), mPopupWindow.getHeight());
@@ -508,6 +509,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     };
 
     private void updateArrowLocation() {
+        if(mPopupWindow == null) return;
         RectF achorRect = SimpleTooltipUtils.calculeRectOnScreen(mAnchorView);
         RectF contentViewRect = SimpleTooltipUtils.calculeRectOnScreen(mContentLayout);
         float x, y;


### PR DESCRIPTION
Once the popUp is shown, an updatePopUpLocation method is called after a delay of 400ms to readjust the popUp after the anchorView position is finalized. During this delay, if the user taps anywhere the popUp is dismissed marking the popUpWindow instance null before the updatePopUpLocation method is called. Now when updatePopUpLocation is called after the delay, it gets popUpWindow instance as null thus throwing NullPointerException.